### PR TITLE
Minor fixes/suggestions

### DIFF
--- a/01_materials/slides/10_numpy.ipynb
+++ b/01_materials/slides/10_numpy.ipynb
@@ -94,7 +94,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "id": "cea5f938",
       "metadata": {
         "id": "cea5f938"
@@ -179,7 +179,7 @@
         "id": "19868422"
       },
       "source": [
-        "We can create arrays with placeholder content in several ways. This is useful when we know how many elements will be in an array, but not their values, as `numpy` arrays have fixed size. The full list is in [`numpy`'s documentation](https://numpy.org/devdocs/user/basics.creation.html#arrays-creation)."
+        "We can create arrays with placeholder content in several ways. This is useful when we know how many elements will be in an array, but not their values, as `numpy` arrays have fixed size. You can find other methods for array creation in [`numpy`'s documentation](https://numpy.org/devdocs/user/basics.creation.html#arrays-creation)."
       ]
     },
     {
@@ -239,7 +239,7 @@
       },
       "outputs": [],
       "source": [
-        "# create a 1D array from 1 until 10 in steps of 2\n",
+        "# create a 1D array from 1 to 10 in steps of 2\n",
         "np.arange(1, 10, 2)"
       ]
     },
@@ -1231,7 +1231,7 @@
         "id": "bae12ead"
       },
       "source": [
-        "To filter use a Boolean expression as a mask, pass it into square brackets after the array to mask."
+        "To filter an array, we pass the mask (e.g., `tens % 3 == 0`) as the array index:"
       ]
     },
     {
@@ -1546,7 +1546,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
+      "display_name": "python-env",
       "language": "python",
       "name": "python3"
     },
@@ -1560,7 +1560,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.11.8"
+      "version": "3.11.14"
     },
     "rise": {
       "scroll": true,


### PR DESCRIPTION
<!-- PULL REQUEST TITLE: UofT-DSI | <Python> - Numpy section-->

## Numpy Slides
### Overview 
A few suggestions for improving the clarity of the lecture notes for `python/01_materials/slides/10_numpy.ipynb`. Feel free to use or discard as you see fit.

### Content clarity
1. Numpy documentation (line 182): was not clear what the list was without clicking the link
2. Section: logic and filtering (line 1234): changed to clearer, more intuitive wording that matches the second code chunk.
```markdown
To filter an array, we pass the mask (e.g., `tens % 3 == 0`) as the array index:
```
```python
# also works 
mask = tens % 3 == 0
tens[mask]
```
Alternative wording: 
```markdown
To filter an array, we apply the Boolean expression (e.g., `tens % 3 == 0`) as a mask over the entire array by passing the mask as the array index (e.g., `tens[tens % 3 == 0`]).
```
3.  The intention of the paragraph + code (see below) isn't entirely clear - are the code blocks demonstrating `pandas` or `numpy`? Some inline code comments might be helpful here. Perhaps also a link to `pandas` documentation?
```markdown
In this case, `genfromtxt` returned a _structured array_, a different type of array than the ones we have seen 
so far. We can refer to fields by putting the field name as a string in square brackets, similar to referencing 
a dictionary key. However, we will soon see a data type in another package, `pandas`, that is even better 
suited to working with columns in tabular data like this.
```
```python
np.median(housing_data['housing_median_age'])
```
```python
housing_data['median_income'].mean()
```
4. Typo in the last code block - either the function should it be `.median()` or the column reference should be [`mean_income`]. Note that if you change it to `.median()` it throws an error (presumably because `pandas` has not been imported?) If `.mean()` was intended, it seems odd given the line above used `np.median()`

### Minor typos
1. changed "until" to "to" in a comment for consistency (line 242)
2. `housing_data['median_income'].mean()` should either be `.median()` or `['mean_income']` (last code block)
```python
housing_data['median_income'].mean()
```
### Other notes
Modifications were made on a system running macOS, using Python 3.11.14 (python-env) as the kernel. 
- `execution_count` may need to be set back to `NULL` (line 97)
- `display_name` may need to be set back to `Python 3 (ipykernal)` (line 1549)
- `version` may need to be set back to `3.11.8` (line 1563)

---
## Checklist
- [x] I can confirm that my changes are working as intended
